### PR TITLE
1.9.7a Patches

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Surge Breaker (1.9.6a alpha)
+# Surge Breaker (1.9.7a alpha)
  *Surge Breaker - Genius Studios Project*
  
 *This is the Unity Project for the Surge Breaker Genius Studios Project.*
 
-## 1.9.6a Polish Update
+## 1.9.7a Polish Update
 
 Note: This is a fully functional, playable demo version of the game.
 

--- a/Titan Knight (HGU Project)/Assets/Prefabs/Characters/Enemies/Player Enemies/Player Enemy.prefab
+++ b/Titan Knight (HGU Project)/Assets/Prefabs/Characters/Enemies/Player Enemies/Player Enemy.prefab
@@ -824,7 +824,7 @@ NavMeshAgent:
   m_GameObject: {fileID: 5622125658679942988}
   m_Enabled: 1
   m_AgentTypeID: 0
-  m_Radius: 2.5
+  m_Radius: 0.8
   m_Speed: 6
   m_Acceleration: 12
   avoidancePriority: 50
@@ -848,7 +848,7 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 4.39, y: 2.24, z: 4.73}
+  m_Size: {x: 3, y: 3, z: 3}
   m_Center: {x: 0, y: 0, z: 0}
 --- !u!1 &5660327750483879969
 GameObject:


### PR DESCRIPTION
- Fixed: New enemies did not attack the player.

[Solution]: The radius of the NavMesh Agents must not be so big that they can not reach the player. A good radius, despite the size of the enemy, is 0.8.